### PR TITLE
Add log.level to logstash.yml template file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 .kitchen
+.idea

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,7 @@ logstash_nice:       19
 logstash_open_files: 16384
 logstash_use_gc_logging: false
 logstash_kill_on_stop_timeout: 0
+logstash_log_level: info
 
 ############
 ##  Package

--- a/templates/logstash.yml.j2
+++ b/templates/logstash.yml.j2
@@ -152,7 +152,7 @@ path.config: /etc/logstash/conf.d
 #   * debug
 #   * trace
 #
-# log.level: info
+log.level: {{ logstash_log_level }}
 path.logs: /var/log/logstash
 #
 # ------------ Other Settings --------------


### PR DESCRIPTION
This allows us to teporarily set logstash to only log ERRORs, saving
space until we've been able to run new logging config into Prod