### PR TITLE
Pri 293 fix logstash validation errors

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -10,6 +10,8 @@ provisioner:
   ansible_verbosity: 2
   ansible_diff: true
   ansible_extra_flags: <%= ENV['ANSIBLE_EXTRA_FLAGS'] %>
+  ignore_paths_from_root:
+    - .kitchen
 
 platforms:
   - name: ubuntu-14.04
@@ -21,3 +23,6 @@ platforms:
 
 suites:
   - name: default
+
+transport:
+  max_ssh_sessions: 4

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,6 +3,8 @@
 - name: Validate logstash config
   shell: >
       {{ logstash_config_validate_cmd }}
+  args:
+    chdir: "{{ logstash_home_dir }}"
 
 - name: Restart logstash
   service: name=logstash state=restarted


### PR DESCRIPTION
logstash validation gives erroneous error messages if run from /etc/logstash. It should be run from LS_HOME in order for output to be correct